### PR TITLE
Fix for variable df output

### DIFF
--- a/Stats.py
+++ b/Stats.py
@@ -143,4 +143,4 @@ def get_disk_usage_details(footage_path):
 	else:
 		logger.debug("Disk space raw result:\n{0}".format(completed.stdout.decode("UTF-8")))
 		line = completed.stdout.decode("UTF-8").splitlines()[1]
-		return line[0:15].strip(), line[15:21].strip(), line[21:27].strip(), line[26:33].strip(), line[32:38].strip(), line[37:].strip()
+		return re.split("\s+", line)


### PR DESCRIPTION
Stats generation fails when the output from df is not exactly as expected:
```
Sep  9 11:00:46 sv002 RemoveOld.py[23613]: Traceback (most recent call last):
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:   File "/home/teslacam/TeslaCamMerge/RemoveOld.py", line 101, in <module>
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:     main()
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:   File "/home/teslacam/TeslaCamMerge/RemoveOld.py", line 42, in main
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:     Stats.generate_stats_image()
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:   File "/home/teslacam/TeslaCamMerge/Stats.py", line 37, in generate_stats_image
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:     "DISK_COLOR" : get_disk_color(used_percentage)
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:   File "/home/teslacam/TeslaCamMerge/Stats.py", line 61, in get_disk_color
Sep  9 11:00:46 sv002 RemoveOld.py[23613]:     used = int(used_percentage[:-1])
Sep  9 11:00:46 sv002 RemoveOld.py[23613]: ValueError: invalid literal for int() with base 10: '9T  3'
```

DF variable output format example:

```
root@sv002:/home/teslacam# df -h /mnt/TeslaCam
Filesystem              Size  Used Avail Use% Mounted on
//10.10.10.10/TeslaCam  8.2T  7.9T  301G  97% /mnt/TeslaCam

root@sv002:/home/teslacam# df -h /home
Filesystem      Size  Used Avail Use% Mounted on
/dev/sda1        57G  5.1G   49G  10% /
```